### PR TITLE
Working extended file attributes for BSD

### DIFF
--- a/src/java.base/bsd/classes/sun/nio/fs/BsdFileSystem.java
+++ b/src/java.base/bsd/classes/sun/nio/fs/BsdFileSystem.java
@@ -69,7 +69,7 @@ class BsdFileSystem extends UnixFileSystem {
 
     @Override
     void copyNonPosixAttributes(int ofd, int nfd) {
-        UnixUserDefinedFileAttributeView.copyExtendedAttributes(ofd, nfd);
+        UnixUserDefinedFileAttributeView.copyExtendedAttributes(ofd, nfd, UnixUserDefinedFileAttributeView.FileAttributeType.BSD);
     }
 
     /**

--- a/src/java.base/bsd/classes/sun/nio/fs/BsdUserDefinedFileAttributeView.java
+++ b/src/java.base/bsd/classes/sun/nio/fs/BsdUserDefinedFileAttributeView.java
@@ -29,9 +29,10 @@ class BsdUserDefinedFileAttributeView
     extends UnixUserDefinedFileAttributeView
 {
     BsdUserDefinedFileAttributeView(UnixPath file, boolean followLinks) {
-        super(file, followLinks);
+        super(file, followLinks, UnixUserDefinedFileAttributeView.FileAttributeType.BSD);
     }
 
+    // Should be equal to EXTATTR_MAXNAMELEN
     @Override
     protected int maxNameLength() {
         return 255;

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -43,6 +43,11 @@ import static sun.nio.fs.UnixNativeDispatcher.*;
 abstract class UnixUserDefinedFileAttributeView
     extends AbstractUserDefinedFileAttributeView
 {
+    enum FileAttributeType {
+        LINUX,
+        BSD
+    };
+
     private static final Unsafe unsafe = Unsafe.getUnsafe();
 
     private static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
@@ -55,16 +60,24 @@ abstract class UnixUserDefinedFileAttributeView
 
     private final UnixPath file;
     private final boolean followLinks;
+    private final FileAttributeType attributeType;
 
     UnixUserDefinedFileAttributeView(UnixPath file, boolean followLinks) {
+        this(file, followLinks, FileAttributeType.LINUX);
+    }
+
+    UnixUserDefinedFileAttributeView(UnixPath file, boolean followLinks, FileAttributeType attributeType) {
         this.file = file;
         this.followLinks = followLinks;
+        this.attributeType = attributeType;
     }
 
     private byte[] nameAsBytes(UnixPath file, String name) throws IOException {
         if (name == null)
             throw new NullPointerException("'name' is null");
-        name = USER_NAMESPACE + name;
+        if (attributeType == FileAttributeType.LINUX) {
+            name = USER_NAMESPACE + name;
+        }
         byte[] bytes = Util.toBytes(name);
         if (bytes.length > maxNameLength()) {
             throw new FileSystemException(file.getPathForExceptionMessage(),
@@ -79,35 +92,54 @@ abstract class UnixUserDefinedFileAttributeView
     protected abstract int maxNameLength();
 
     // Parses buffer as array of NULL-terminated C strings.
-    private static List<String> asList(long address, int size) {
+    private static List<String> asList(long address, int size, FileAttributeType attributeType) {
         List<String> list = new ArrayList<>();
         int start = 0;
         int pos = 0;
-        while (pos < size) {
-            if (unsafe.getByte(address + pos) == 0) {
-                int len = pos - start;
+        if (attributeType == FileAttributeType.LINUX) {
+            while (pos < size) {
+                if (unsafe.getByte(address + pos) == 0) {
+                    int len = pos - start;
+                    byte[] value = new byte[len];
+                    unsafe.copyMemory(null, address+start, value,
+                        Unsafe.ARRAY_BYTE_BASE_OFFSET, len);
+                    String s = Util.toString(value);
+                    list.add(s);
+                    start = pos + 1;
+                }
+                pos++;
+            }
+            // Only "user" namespace attributes
+            list = list.stream()
+                    .filter(s -> s.startsWith(USER_NAMESPACE))
+                    .map(s -> s.substring(USER_NAMESPACE.length()))
+                    .toList();
+        } else { // FileAttributeType.BSD
+            while (pos < size) {
+                int len = unsafe.getByte(address + pos) & 0xFF;
+                start = pos + 1;
                 byte[] value = new byte[len];
                 unsafe.copyMemory(null, address+start, value,
                     Unsafe.ARRAY_BYTE_BASE_OFFSET, len);
                 String s = Util.toString(value);
                 list.add(s);
-                start = pos + 1;
+                pos = start + len;
             }
-            pos++;
         }
+
         return list;
     }
 
     // runs flistxattr, increases buffer size up to MAX_LISTXATTR_BUF_SIZE if required
-    private static List<String> list(int fd, int bufSize) throws UnixException {
+    private static List<String> list(int fd, int bufSize, FileAttributeType attributeType) throws UnixException {
         try {
             try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(bufSize)) {
                 int n = flistxattr(fd, buffer.address(), bufSize);
-                return asList(buffer.address(), n);
+                return asList(buffer.address(), n, attributeType);
             } // release buffer before recursion
         } catch (UnixException x) {
             if (x.errno() == ERANGE && bufSize < MAX_LISTXATTR_BUF_SIZE) {
-                return list(fd, bufSize * 2); // try larger buffer size:
+                return list(fd, bufSize * 2, attributeType); // try larger buffer size:
             } else {
                 throw x;
             }
@@ -127,11 +159,7 @@ abstract class UnixUserDefinedFileAttributeView
             x.rethrowAsIOException(file);
         }
         try {
-            List<String> attrNames = list(fd, MIN_LISTXATTR_BUF_SIZE);
-            return attrNames.stream()
-                    .filter(s -> s.startsWith(USER_NAMESPACE))
-                    .map(s -> s.substring(USER_NAMESPACE.length()))
-                    .toList();
+            return list(fd, MIN_LISTXATTR_BUF_SIZE, attributeType);
         } catch (UnixException x) {
             throw new FileSystemException(file.getPathForExceptionMessage(),
                 null, "Unable to get list of extended attributes: " +
@@ -324,8 +352,12 @@ abstract class UnixUserDefinedFileAttributeView
      *          file descriptor for target file
      */
     static void copyExtendedAttributes(int ofd, int nfd) {
+        copyExtendedAttributes(ofd, nfd, FileAttributeType.LINUX);
+    }
+
+    static void copyExtendedAttributes(int ofd, int nfd, FileAttributeType attributeType) {
         try {
-            List<String> attrNames = list(ofd, MIN_LISTXATTR_BUF_SIZE);
+            List<String> attrNames = list(ofd, MIN_LISTXATTR_BUF_SIZE, attributeType);
             for (String name : attrNames) {
                 try {
                     copyExtendedAttribute(ofd, Util.toBytes(name), nfd);


### PR DESCRIPTION
* Add code that handles the BSD extended file attribute semantics. This allows them to work correctly on FreeBSD.
* Make the Linux semantics the default to avoid changing the Linux code.  Ideally we'd be explicit everywhere instead, but this likely makes merges simpler.