### PR TITLE
Misc Changes

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -560,7 +560,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
       TOOLCHAIN_CFLAGS_JDK="-pipe"
       TOOLCHAIN_CFLAGS_JDK_CONLY="-fno-strict-aliasing" # technically NOT for CXX
 
-      CXXSTD_CXXFLAG="-std=gnu++98"
       FLAGS_CXX_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$CXXSTD_CXXFLAG -Werror],
                                                     IF_FALSE: [CXXSTD_CXXFLAG=""])
       TOOLCHAIN_CFLAGS_JDK_CXXONLY="$CXXSTD_CXXFLAG"

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -46,6 +46,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBNET, \
     DISABLED_WARNINGS_gcc_net_util_md.c := format-nonliteral, \
     DISABLED_WARNINGS_gcc_NetworkInterface.c := unused-function, \
     DISABLED_WARNINGS_clang_net_util_md.c := format-nonliteral, \
+    DISABLED_WARNINGS_clang_bsd_DefaultProxySelector.c := deprecated-non-prototype, \
     DISABLED_WARNINGS_clang_aix_DefaultProxySelector.c := deprecated-non-prototype, \
     DISABLED_WARNINGS_clang_aix_NetworkInterface.c := gnu-pointer-arith, \
     DISABLED_WARNINGS_microsoft_InetAddress.c := 4244, \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -264,6 +264,7 @@ ifeq ($(call isTargetOs, windows macosx), false)
         DISABLED_WARNINGS_clang_aix_gtk3_interface.c := parentheses logical-op-parentheses, \
         DISABLED_WARNINGS_clang_aix_sun_awt_X11_GtkFileDialogPeer.c := parentheses, \
         DISABLED_WARNINGS_clang_aix_awt_InputMethod.c := sign-compare, \
+        DISABLED_WARNINGS_clang_bsd := deprecated-non-prototype, \
         LDFLAGS := $(LDFLAGS_JDKLIB) \
             $(call SET_SHARED_LIBRARY_ORIGIN) \
             -L$(INSTALL_LIBRARIES_HERE), \


### PR DESCRIPTION
* Fix compilation with clang-16
* Since jdk16 the c++ build standard is c++14. Remove -std=gnu++98
* Sync os_bsd_aarch64.cpp with linux. Fixes runtime/Unsafe/InternalErrorTest.java test.