### PR TITLE
Enable IPv6 dual protocol socket support on FreeBSD

### DIFF
--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -199,7 +199,7 @@ Java_jdk_internal_util_SystemProps_00024Raw_platformProperties(JNIEnv *env, jcla
     }
 #endif
 
-#ifdef _BSDONLY_SOURCE
+#ifdef __OpenBSD__
     PUTPROP(propArray, _java_net_preferIPV4Stack_NDX, sprops->java_net_preferIPv4Stack);
 #endif
 

--- a/src/java.base/share/native/libjava/java_props.h
+++ b/src/java.base/share/native/libjava/java_props.h
@@ -102,7 +102,7 @@ typedef struct {
     char *exceptionList;
 #endif
 
-#ifdef _BSDONLY_SOURCE
+#ifdef __OpenBSD__
     char *java_net_preferIPv4Stack; /* Needed to default to true OpenBSD. */
 #endif
 

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -382,7 +382,7 @@ GetJavaProperties(JNIEnv *env)
     /* patches/service packs installed */
     sprops.patch_level = NULL;      // leave it undefined
 
-#ifdef _BSDONLY_SOURCE
+#ifdef __OpenBSD__
     sprops.java_net_preferIPv4Stack = "true";
 #endif
 

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -280,7 +280,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
         return handleSocketError(env, errno);
     }
 
-#ifndef _BSDONLY_SOURCE
+#ifndef __OpenBSD__
     /*
      * If IPv4 is available, disable IPV6_V6ONLY to ensure dual-socket support.
      */


### PR DESCRIPTION
It is possible to limit the jvm to default to IPv4 only sockets by setting `java.net.preferIPv4Stack` to true. This is the default on OpenBSD, but for otehr BSD's we follow the Java specification that sockets should accept both IPv4 and IPv6 when the latter is available.

This work is sponsored by The FreeBSD Foundation

Issue: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=274964