### PR TITLE
Add missing call to StubGenerator::generate_atomic_entry_points

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -7109,7 +7109,7 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-#if (defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)) || defined(_BSDONLY_SOURCE)
+#if (defined (LINUX) || defined(_BSDONLY_SOURCE)) && !defined (__ARM_FEATURE_ATOMICS)
 
   // ARMv8.1 LSE versions of the atomic stubs used by Atomic::PlatformXX.
   //
@@ -8737,11 +8737,11 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_poly1305_processBlocks = generate_poly1305_processBlocks();
     }
 
-#if defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)
+#if (defined (LINUX) || defined(_BSDONLY_SOURCE)) && !defined (__ARM_FEATURE_ATOMICS)
 
     generate_atomic_entry_points();
 
-#endif // LINUX
+#endif // LINUX || _BSDONLY_SOURCE
 
     if (UseSecondarySupersTable) {
       StubRoutines::_lookup_secondary_supers_table_slow_path_stub = generate_lookup_secondary_supers_table_slow_path_stub();


### PR DESCRIPTION
and correct use of __ARM_FEATURE_ATOMICS for _BSDONLY_SOURCE.

While we haven't yet back ported runtime detection of HWCAPs to 21u yet, it doesn't hurt to back port this correction now. One less thing to remember to do.

Currently on 21u runtime detection of HWCAPs does not include `HWCAP_ATOMICS` so `UseLSE` is never set there and the missing call to generate_atomic_entry_points does not have an adverse affect. If/when we back port runtime detection of HWCAPS here it this part will be ready for it.

Note that this particular fix does not need to be back ported further as [17u](https://github.com/battleblow/jdk17u/blob/bsd-port/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp#L7682) and [11u](https://github.com/battleblow/jdk11u/blob/bsd-port/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp#L6427) are already correct.