### PR TITLE
Misc BSD GHA and OpenBSD Changes

### DIFF
--- a/.github/actions/do-build-vm/action.yml
+++ b/.github/actions/do-build-vm/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs
@@ -83,7 +83,7 @@ runs:
 
       # This is the best way I found to abort the job with an error message
     - name: 'Notify about build failures'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: core.setFailed('Build failed. See summary for details.')
       if: steps.check.outputs.failure == 'true'

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: 'Restore Cached VM Packages'
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -184,7 +184,7 @@ jobs:
           sudo df -h
 
       - name: 'Save VM Packages'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -298,7 +298,7 @@ jobs:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
       vm-arch: 'x86_64'
-      vm-release: "7.8"
+      vm-release: "7.9"
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.prepare.outputs.openbsd-x64 == 'true'
@@ -366,7 +366,7 @@ jobs:
     with:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
-      vm-release: 7.8
+      vm-release: 7.9
       vm-arch: x86_64
 
   test-freebsd-x64:

--- a/.github/workflows/test-freebsd.yml
+++ b/.github/workflows/test-freebsd.yml
@@ -223,7 +223,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -231,7 +231,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Restore Cached VM Packages
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -238,7 +238,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -246,7 +246,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -34,6 +34,13 @@
 #include "util.h"
 #include "error_messages.h"
 
+#define RESTARTABLE(_cmd, _result) do { \
+  do { \
+    _result = _cmd; \
+  } while((_result == -1) && (errno == EINTR)); \
+} while(0)
+
+
 static char *skipWhitespace(char *p) {
     while ((*p != '\0') && isspace(*p)) {
         p++;
@@ -72,6 +79,9 @@ closeDescriptors(void)
 {
 #if defined(__FreeBSD__)
     closefrom(STDERR_FILENO + 1);
+#elif defined(_BSDONLY_SOURCE)
+    int err;
+    RESTARTABLE(closefrom(STDERR_FILENO + 1), err);
 #else
     DIR *dp;
     struct dirent *dirp;


### PR DESCRIPTION
GHA: Use OpenBSD 7.9 to build and test
GHA: Upgrade remaining Node.js 20 to 24
OpenBSD: Use restartable closefrom(2) in jdwp closeDescriptors()