### PR TITLE
Fix building with clang 22

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
+++ b/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
@@ -339,7 +339,7 @@ Java_sun_java2d_xr_XRBackendNative_createPixmap(JNIEnv *env, jobject this,
 JNIEXPORT jint JNICALL
 Java_sun_java2d_xr_XRBackendNative_createPictureNative
  (JNIEnv *env, jclass cls, jint drawable, jlong formatPtr) {
-  XRenderPictureAttributes pict_attr;
+  XRenderPictureAttributes pict_attr = { 0 };
   return XRenderCreatePicture(awt_display, (Drawable) drawable,
                               (XRenderPictFormat *) jlong_to_ptr(formatPtr),
                                0, &pict_attr);


### PR DESCRIPTION
error: variable 'pict_attr' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]
