### PR TITLE
Serviceability backports

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdCDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdCDebugger.java
@@ -41,9 +41,11 @@ import sun.jvm.hotspot.utilities.*;
 
 class BsdCDebugger implements CDebugger {
   private BsdDebugger dbg;
+  private boolean isDarwin;             // variant for MacOS
 
   BsdCDebugger(BsdDebugger dbg) {
     this.dbg = dbg;
+    this.isDarwin = PlatformInfo.getOS().equals("darwin");
   }
 
   public List<ThreadProxy> getThreadList() throws DebuggerException {
@@ -58,30 +60,46 @@ class BsdCDebugger implements CDebugger {
     if (pc == null) {
       return null;
     }
-    List<LoadObject> objs = getLoadObjectList();
-    Object[] arr = objs.toArray();
-    // load objects are sorted by base address, do binary search
-    int mid  = -1;
-    int low  = 0;
-    int high = arr.length - 1;
 
-    while (low <= high) {
-       mid = (low + high) >> 1;
-       LoadObject midVal = (LoadObject) arr[mid];
-       long cmp = pc.minus(midVal.getBase());
-       if (cmp < 0) {
-          high = mid - 1;
-       } else if (cmp > 0) {
-          long size = midVal.getSize();
-          if (cmp >= size) {
-             low = mid + 1;
-          } else {
-             return (LoadObject) arr[mid];
-          }
-       } else { // match found
-          return (LoadObject) arr[mid];
-       }
+    List<LoadObject> objs = getLoadObjectList();
+    if (isDarwin) {
+      Object[] arr = objs.toArray();
+      // load objects are sorted by base address, do binary search
+      int mid  = -1;
+      int low  = 0;
+      int high = arr.length - 1;
+
+      while (low <= high) {
+         mid = (low + high) >> 1;
+         LoadObject midVal = (LoadObject) arr[mid];
+         long cmp = pc.minus(midVal.getBase());
+         if (cmp < 0) {
+            high = mid - 1;
+         } else if (cmp > 0) {
+            long size = midVal.getSize();
+            if (cmp >= size) {
+               low = mid + 1;
+            } else {
+               return (LoadObject) arr[mid];
+            }
+         } else { // match found
+            return (LoadObject) arr[mid];
+         }
+      }
+    } else {
+      /* Typically we have about ten loaded objects here. So no reason to do
+        sort/binary search here. Linear search gives us acceptable performance.
+        This also works more reliably on BSD.*/
+      for (int i = 0; i < objs.size(); i++) {
+        LoadObject ob = objs.get(i);
+        Address base = ob.getBase();
+        long size = ob.getSize();
+        if (pc.greaterThanOrEqual(base) && pc.lessThan(base.addOffsetTo(size))) {
+          return ob;
+        }
+      }
     }
+
     // no match found.
     return null;
   }

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -53,7 +53,8 @@ public class TestMutuallyExclusivePlatformPredicates {
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
                 "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
-                "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7", "isOnWayland");
+                "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7", "isOnWayland",
+                "isOpenBSD");
 
         public final List<String> methodNames;
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -138,6 +138,10 @@ public class Platform {
         return osName.toLowerCase().endsWith("bsd");
     }
 
+    public static boolean isOpenBSD() {
+        return osName.toLowerCase().equals("openbsd");
+    }
+
     private static boolean isOs(String osname) {
         return osName.toLowerCase(ROOT).startsWith(osname.toLowerCase(ROOT));
     }
@@ -256,6 +260,8 @@ public class Platform {
             return false; // SA is not enabled.
         }
         if (isAix()) {
+            return false; // SA not implemented.
+        } else if (isOpenBSD()) {
             return false; // SA not implemented.
         } else if (isLinux()) {
             if (isS390x() || isARM()) {


### PR DESCRIPTION
I'm trying a new approach for backporting jdk25/mainline corrections. Previously I tried applying all corrections at once in one branch. Each time I've tried this it gets unwieldy and I stall. I'm now trying a test case based approach where I backport the corrections that fix specific tests. This PR focuses on fixing the hotspot tier1 serviceability tests on OpenBSD.  Since OpenBSD doesn't currently support the serviceability agent there are still a number of failures for FreeBSD. @snake66 @battleblow, this would be a good place to divvy up the work.